### PR TITLE
Add continuous integration testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,34 @@
+name: Build and run tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v3
+        with:
+          python-version: "3.x"
+      - name: Install test dependencies
+        run: |
+          pip install -r test_requirements.txt
+          pip install pytest-cov
+      - name: Install package
+        run: |
+          pip install flit
+          flit install
+      - name: Run tests
+        run: |
+          pytest . --log-level DEBUG --cov-config=.coveragerc --cov=findoutlie --doctest-modules
+      - name: Collect code coverage data
+        run: |
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 __pycache__/
+# Output from coverage command
+.coverage


### PR DESCRIPTION
This commit adds "continuous integration testing".  This is testing that
runs on every commit that you push to your repository.  We will cover
this in the class today (Monday 11th).